### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: php
 php:
 - 7.1
 - 7.2
+- 7.3
+- 7.4
 
 install:
 - travis_retry composer install --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,12 @@
         "php": ">=7.1.0"
     },
     "autoload": {
-        "classmap": [
-            "src/"
-        ],
         "psr-4": {
-            "Narokishi\\ObjectValidator\\": "src/",
+            "Narokishi\\ObjectValidator\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "Narokishi\\Tests\\": "tests/"
         }
     },

--- a/tests/AbstractRuleTest.php
+++ b/tests/AbstractRuleTest.php
@@ -19,7 +19,7 @@ class AbstractRuleTest extends TestCase
     /**
      * @throws \ReflectionException
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ruleClass = $this->getMockForAbstractClass(AbstractRule::class, ['AbstractValue']);
     }

--- a/tests/ValidationExceptionTest.php
+++ b/tests/ValidationExceptionTest.php
@@ -23,8 +23,8 @@ class ValidationExceptionTest extends TestCase
     {
         $exception = new ValidationException;
 
-        $this->assertTrue(
-            is_array($exception->getErrors())
+        $this->assertIsArray(
+            $exception->getErrors()
         );
         $this->assertEmpty(
             $exception->getErrors()


### PR DESCRIPTION
# Changed log
- Add `php-7.3` and `php-7.4` versions during Travis CI build.
- It seems that the package uses the `PSR-4` autoloading and it's fine to remove classmap autoloading approach.
- The PHPUnit fixtures should be `protected setUp`. 
- Using the `assertsArray` to assert result type is `array`.